### PR TITLE
bypass soundpool for linux

### DIFF
--- a/lib/app/core/assets/sounds.dart
+++ b/lib/app/core/assets/sounds.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:soundpool/soundpool.dart';
 import 'package:yuno/app/interactor/atoms/config_atom.dart';
@@ -41,6 +43,7 @@ void openRail() {
 }
 
 Future<void> precacheCache() async {
+  if (Platform.isLinux) return;
   _clickSoundId = await rootBundle.load(_clickSound).then((ByteData soundData) {
     return _pool.load(soundData);
   });


### PR DESCRIPTION
Soundpool Platform Interface doesn't seem to be compatible with Linux. The app starts, but it never finishes loading.

I checked the [pkg documentation](https://pub.dev/packages/soundpool) and its oficial repo, and found this [issue](https://github.com/ukasz123/soundpool/issues/46) open.

As of now, if the platform is left unchecked, it will keep the app loading forever (on Linux)

_This commit will disable sound on Linux, but it will at least start the app_

